### PR TITLE
Fix WhatsApp message counter to ignore summary line

### DIFF
--- a/src/components/MessageOrganizer.tsx
+++ b/src/components/MessageOrganizer.tsx
@@ -114,7 +114,13 @@ const MessageOrganizer = () => {
       }
     });
 
-    return groups.length;
+    const blocks = groups
+      .map(group => group.join('\n').trim())
+      .filter(block => block.length > 0);
+
+    const filteredBlocks = blocks.filter(block => !block.startsWith('عدد الرسائل'));
+
+    return filteredBlocks.length;
   };
 
   const checkConnection = async () => {


### PR DESCRIPTION
## Summary
- ensure the WhatsApp message counter filters out summary lines starting with "عدد الرسائل"
- keep counting logic focused on actual message cards only

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9d3847cc48324aeae4db343dcad64