### PR TITLE
Simplify organizer UI to focus on input and results

### DIFF
--- a/src/components/MessageOrganizer.tsx
+++ b/src/components/MessageOrganizer.tsx
@@ -3,16 +3,9 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Separator } from '@/components/ui/separator';
-import { MessageCircle, Settings, Sparkles, Copy, Download, Wifi, Trash2 } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { MessageCircle, Sparkles, Copy, Download, Trash2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
-
-interface ProcessingOptions {
-  sortBy: 'agency' | 'location' | 'amount' | 'original';
-  mergeDuplicates: boolean;
-  showOnlyIds: boolean;
-}
 
 const STORAGE_KEYS = {
   apiKey: 'gemini_api_key',
@@ -150,6 +143,37 @@ const DEFAULT_SYSTEM_PROMPT = `
 يتم كتابة عدد الرسائل بنائن على الرسائل وليس الايديهات
 `;
 
+const DEFAULT_OPTIONS_GUIDANCE = `
+تعليمات إضافية بناءً على خيارات المستخدم:
+- حافظ على نفس ترتيب الرسائل الأصلي دون أي تغيير.
+- لا تدمج أي رسائل حتى لو تكرر الاسم.
+- اعرض جميع الحقول لكل رسالة كما هو موضح في القواعد، ولا تستخدم وضع عرض الايديهات فقط.
+`;
+
+const normalizeDigitString = (value: string) => {
+  const arabicIndicDigits = ['٠', '١', '٢', '٣', '٤', '٥', '٦', '٧', '٨', '٩'] as const;
+  return value.replace(/[٠-٩]/g, (digit) => {
+    const index = arabicIndicDigits.indexOf(digit as (typeof arabicIndicDigits)[number]);
+    return index >= 0 ? String(index) : digit;
+  });
+};
+
+const extractMessageCountValue = (summaryLine: string) => {
+  const countMatch = summaryLine.match(/[0-9٠-٩]+/);
+  if (!countMatch) {
+    return '';
+  }
+
+  const normalized = normalizeDigitString(countMatch[0]);
+  const numericValue = Number(normalized);
+
+  if (Number.isNaN(numericValue)) {
+    return countMatch[0];
+  }
+
+  return numericValue.toLocaleString('ar-EG');
+};
+
 const getInitialStoredValue = (storageKey: string, fallback: string) => {
   if (typeof window !== 'undefined') {
     const storedValue = window.localStorage.getItem(storageKey);
@@ -164,19 +188,13 @@ const MessageOrganizer = () => {
   const [inputText, setInputText] = useState('');
   const [outputText, setOutputText] = useState('');
   const [isProcessing, setIsProcessing] = useState(false);
-  const [isCheckingConnection, setIsCheckingConnection] = useState(false);
-  const [connectionStatus, setConnectionStatus] = useState<'connected' | 'disconnected' | 'unknown'>('unknown');
   const [apiKey] = useState<string>(() => getInitialStoredValue(STORAGE_KEYS.apiKey, DEFAULT_API_KEY));
   const [apiEndpoint] = useState<string>(() =>
     getInitialStoredValue(STORAGE_KEYS.apiEndpoint, DEFAULT_API_ENDPOINT)
   );
-  const [options, setOptions] = useState<ProcessingOptions>({
-    sortBy: 'original',
-    mergeDuplicates: false,
-    showOnlyIds: false,
-  });
   const [hasProcessed, setHasProcessed] = useState(false);
   const [messageCountSummary, setMessageCountSummary] = useState('');
+  const [messageCountValue, setMessageCountValue] = useState('');
   const { toast } = useToast();
 
   useEffect(() => {
@@ -197,89 +215,13 @@ const MessageOrganizer = () => {
     () =>
       JSON.stringify({
         input: inputText,
-        options,
         apiKey,
         apiEndpoint,
       }),
-    [apiEndpoint, apiKey, inputText, options]
+    [apiEndpoint, apiKey, inputText]
   );
   const lastProcessedSignature = useRef<string>('');
   const pendingAutoSignature = useRef<string | null>(null);
-
-  const checkConnection = async () => {
-    if (!apiKey.trim()) {
-      toast({
-        title: "خطأ",
-        description: "يرجى إدخال مفتاح API الخاص بـ Gemini",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    if (!apiEndpoint.trim()) {
-      toast({
-        title: "خطأ",
-        description: "يرجى إدخال رابط واجهة Gemini API",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    setIsCheckingConnection(true);
-
-    try {
-      const trimmedEndpoint = apiEndpoint.trim();
-      const key = encodeURIComponent(apiKey.trim());
-      const requestUrl = `${trimmedEndpoint}${trimmedEndpoint.includes('?') ? '&' : '?'}key=${key}`;
-
-      const response = await fetch(requestUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          contents: [{
-            parts: [{
-              text: 'مرحبا'
-            }]
-          }],
-          generationConfig: {
-            temperature: 0.1,
-            topK: 1,
-            topP: 1,
-            maxOutputTokens: 10,
-          },
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const data = await response.json();
-      
-      if (data.candidates && data.candidates[0]) {
-        setConnectionStatus('connected');
-        toast({
-          title: "متصل",
-          description: "الاتصال مع Gemini API يعمل بشكل صحيح",
-          variant: "default",
-        });
-      } else {
-        throw new Error('Invalid response format');
-      }
-    } catch (error) {
-      console.error('Connection test failed:', error);
-      setConnectionStatus('disconnected');
-      toast({
-        title: "خطأ في الاتصال",
-        description: "فشل الاتصال مع Gemini API. تحقق من المفتاح.",
-        variant: "destructive",
-      });
-    } finally {
-      setIsCheckingConnection(false);
-    }
-  };
 
   const processMessages = useCallback(
     async (trigger: 'manual' | 'auto' = 'manual') => {
@@ -319,29 +261,7 @@ const MessageOrganizer = () => {
       setIsProcessing(true);
 
       try {
-        const sortInstruction = {
-          original: 'حافظ على نفس ترتيب الرسائل الأصلي دون أي تغيير.',
-          agency: 'رتب البطاقات تصاعدياً حسب اسم الوكالة.',
-          location: 'رتب البطاقات تصاعدياً حسب العنوان.',
-          amount: 'رتب البطاقات حسب قيمة المبالغ من الأصغر إلى الأكبر إن وُجدت، وإن لم تتوفر مبالغ فحافظ على الترتيب الأصلي.',
-        }[options.sortBy];
-
-        const mergeInstruction = options.mergeDuplicates
-          ? 'ادمج الرسائل التي تمتلك نفس الاسم تماماً مع تجميع ايديهاتها في بطاقة واحدة مع ذكر كل ايدي في سطر مستقل.'
-          : 'لا تدمج أي رسائل حتى لو تكرر الاسم.';
-
-        const showOnlyIdsInstruction = options.showOnlyIds
-          ? 'فعّل وضع عرض الايديهات فقط: اعرض كل وكالة بالشكل "وكالة <اسم الوكالة>" يتبعها الايديهات المرتبطة بها فقط. الايديهات التي لا تعرف وكالتها تُجمع تحت "وكالة غير معروفة".'
-          : 'اعرض جميع الحقول لكل رسالة كما هو موضح في القواعد، ولا تستخدم وضع عرض الايديهات فقط.';
-
-        const optionsGuidance = `
-تعليمات إضافية بناءً على خيارات المستخدم:
-- ${sortInstruction}
-- ${mergeInstruction}
-- ${showOnlyIdsInstruction}
-`;
-
-        const systemPrompt = `${DEFAULT_SYSTEM_PROMPT.trim()}\n\n${optionsGuidance}`;
+        const systemPrompt = `${DEFAULT_SYSTEM_PROMPT.trim()}\n\n${DEFAULT_OPTIONS_GUIDANCE.trim()}`;
 
         const trimmedEndpoint = apiEndpoint.trim();
         const key = encodeURIComponent(apiKey.trim());
@@ -376,13 +296,16 @@ const MessageOrganizer = () => {
         if (data.candidates && data.candidates[0] && data.candidates[0].content) {
           const result = data.candidates[0].content.parts[0].text?.trim();
           if (result) {
-            const summaryMatch = result.match(/عدد الرسائل المحللة\s*:\s*\d+/);
+            const summaryMatch = result.match(/عدد الرسائل المحللة\s*:\s*[0-9٠-٩]+/);
             let summaryLine = '';
             let cleanedResult = result;
 
             if (summaryMatch) {
               summaryLine = summaryMatch[0].trim();
+              setMessageCountValue(extractMessageCountValue(summaryLine));
               cleanedResult = result.replace(summaryMatch[0], '').trimEnd();
+            } else {
+              setMessageCountValue('');
             }
 
             setOutputText(cleanedResult.trimEnd());
@@ -407,6 +330,7 @@ const MessageOrganizer = () => {
       } catch (error) {
         console.error('Error processing messages:', error);
         setMessageCountSummary('');
+        setMessageCountValue('');
         toast({
           title: "خطأ في المعالجة",
           description: trigger === 'manual' ? "حدث خطأ أثناء معالجة الرسائل. يرجى المحاولة مرة أخرى." : "فشل تحديث الخيارات تلقائياً. حاول المعالجة يدوياً.",
@@ -416,7 +340,7 @@ const MessageOrganizer = () => {
         setIsProcessing(false);
       }
     },
-    [apiEndpoint, apiKey, autoSignature, inputText, options, toast]
+    [apiEndpoint, apiKey, autoSignature, inputText, toast]
   );
 
   useEffect(() => {
@@ -439,7 +363,7 @@ const MessageOrganizer = () => {
 
     pendingAutoSignature.current = null;
     processMessages('auto');
-  }, [apiEndpoint, apiKey, autoSignature, hasProcessed, inputText, isProcessing, options, processMessages]);
+  }, [apiEndpoint, apiKey, autoSignature, hasProcessed, inputText, isProcessing, processMessages]);
 
   useEffect(() => {
     if (!pendingAutoSignature.current) {
@@ -503,10 +427,9 @@ const MessageOrganizer = () => {
     setInputText('');
     setOutputText('');
     setHasProcessed(false);
-    setConnectionStatus('unknown');
     setIsProcessing(false);
-    setIsCheckingConnection(false);
     setMessageCountSummary('');
+    setMessageCountValue('');
     pendingAutoSignature.current = null;
     lastProcessedSignature.current = '';
   };
@@ -514,76 +437,17 @@ const MessageOrganizer = () => {
   return (
     <div className="min-h-screen p-4 md:p-6 lg:p-8 font-arabic">
       <div className="max-w-6xl mx-auto space-y-6">
-        {/* Header */}
-        <div className="text-center space-y-4 animate-fade-in">
-          <div className="flex items-center justify-center gap-3 mb-4">
-            <div className="p-3 rounded-full bg-gradient-primary shadow-medium">
-              <MessageCircle className="h-8 w-8 text-primary-foreground" />
-            </div>
-            <h1 className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-primary to-primary-glow bg-clip-text text-transparent">
-              منظم رسائل واتساب
-            </h1>
-          </div>
-          <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-            استخدم الذكاء الاصطناعي Gemini 2.5 لترتيب وتنظيم رسائل واتساب الخاصة بوكالات العملة المشفرة
-          </p>
-        </div>
-
         <div className="grid lg:grid-cols-2 gap-6">
           {/* Input Section */}
           <Card className="animate-slide-up shadow-medium bg-gradient-card border-border/50">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
-                <Settings className="h-5 w-5 text-primary" />
-                إعدادات المعالجة
+                <Sparkles className="h-5 w-5 text-primary" />
+                الصق رسائل واتساب
               </CardTitle>
-              <CardDescription>
-                أدخل رسائل واتساب واختر خيارات المعالجة
-              </CardDescription>
+              <CardDescription>أدخل رسائل واتساب المراد تحليلها وترتيبها</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <div className="rounded-md border border-primary/30 bg-primary/10 px-4 py-3 text-sm text-primary">
-                  تم تثبيت إعدادات Gemini الافتراضية بما في ذلك مفتاح API، رابط الواجهة، منطق المعالجة، وترتيب النتائج.
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  سيتم استخدام هذه الإعدادات تلقائياً ولا حاجة لإدخالها يدوياً.
-                </p>
-              </div>
-
-              <Separator />
-
-              <div className="space-y-3">
-                <div className="flex items-center space-x-2 space-x-reverse">
-                  <Checkbox
-                    id="mergeDuplicates"
-                    checked={options.mergeDuplicates}
-                    onCheckedChange={(checked) => setOptions({ ...options, mergeDuplicates: !!checked })}
-                  />
-                  <Label htmlFor="mergeDuplicates" className="text-sm">
-                    دمج المكرر (نفس الاسم، ايديهات مختلفة)
-                  </Label>
-                </div>
-
-                <div className="flex items-center space-x-2 space-x-reverse">
-                  <Checkbox
-                    id="showOnlyIds"
-                    checked={options.showOnlyIds}
-                    onCheckedChange={(checked) => setOptions({ ...options, showOnlyIds: !!checked })}
-                  />
-                  <Label htmlFor="showOnlyIds" className="text-sm">
-                    إظهار الايديهات فقط
-                  </Label>
-                </div>
-
-                <p className="text-xs text-muted-foreground">
-                  ترتيب النتائج مثبت على الترتيب الأصلي لضمان الالتزام بالتعليمات المعتمدة.
-                </p>
-              </div>
-
-              <Separator />
-
-              {/* Input Text Area */}
               <div className="space-y-2">
                 <Label htmlFor="inputText">نص رسائل واتساب</Label>
                 <Textarea
@@ -607,49 +471,25 @@ const MessageOrganizer = () => {
                 </div>
               </div>
 
-              {/* Process Button */}
-              <div className="grid grid-cols-2 gap-3">
-                <Button
-                  onClick={checkConnection}
-                  disabled={isCheckingConnection || !apiKey.trim() || !apiEndpoint.trim()}
-                  variant="outline"
-                  size="lg"
-                >
-                  {isCheckingConnection ? (
-                    <>
-                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary"></div>
-                      جاري التحقق...
-                    </>
-                  ) : (
-                    <>
-                      <Wifi className={`h-5 w-5 ${
-                        connectionStatus === 'connected' ? 'text-success' : 
-                        connectionStatus === 'disconnected' ? 'text-destructive' : 
-                        'text-muted-foreground'
-                      }`} />
-                      اتصال
-                    </>
-                  )}
-                </Button>
-                <Button
-                  onClick={() => processMessages()}
-                  disabled={isProcessing || !inputText.trim() || !apiKey.trim() || !apiEndpoint.trim()}
-                  variant="whatsapp"
-                  size="lg"
-                >
-                  {isProcessing ? (
-                    <>
-                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary-foreground"></div>
-                      جاري المعالجة...
-                    </>
-                  ) : (
-                    <>
-                      <Sparkles className="h-5 w-5" />
-                      معالجة الرسائل
-                    </>
-                  )}
-                </Button>
-              </div>
+              <Button
+                onClick={() => processMessages()}
+                disabled={isProcessing || !inputText.trim() || !apiKey.trim() || !apiEndpoint.trim()}
+                variant="whatsapp"
+                size="lg"
+                className="w-full"
+              >
+                {isProcessing ? (
+                  <>
+                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary-foreground"></div>
+                    جاري المعالجة...
+                  </>
+                ) : (
+                  <>
+                    <Sparkles className="h-5 w-5" />
+                    معالجة الرسائل
+                  </>
+                )}
+              </Button>
             </CardContent>
           </Card>
 
@@ -681,6 +521,21 @@ const MessageOrganizer = () => {
             <CardContent>
               {outputText ? (
                 <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="messageCount" className="text-sm font-medium">
+                      عدد الرسائل بعد التحليل
+                    </Label>
+                    <Input
+                      id="messageCount"
+                      value={messageCountValue}
+                      readOnly
+                      placeholder="لم يتم تحديد عدد الرسائل بعد"
+                      className="bg-muted/30"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      يتم تعبئة هذا الحقل تلقائياً عند اكتمال التحليل والترتيب.
+                    </p>
+                  </div>
                   <Textarea
                     value={outputText}
                     readOnly
@@ -694,7 +549,7 @@ const MessageOrganizer = () => {
                   <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
                     <span>عدد الأحرف: {outputText.length.toLocaleString('ar-EG')}</span>
                     <span className="text-xs md:text-sm text-muted-foreground">
-                      يظهر عدد الرسائل المحللة خارج الصندوق أعلى هذا السطر.
+                      يظهر عدد الرسائل المحللة في الحقل أعلاه.
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- hide the auxiliary configuration UI so only the message input and results sections remain visible
- simplify the processing prompt guidance to match the default behavior while keeping message count extraction intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd33052de083248e65784e9223e3ee